### PR TITLE
set session connection timeout to 10 seconds

### DIFF
--- a/lib/parse/client.rb
+++ b/lib/parse/client.rb
@@ -19,6 +19,7 @@ module Parse
       @api_key        = data[:api_key]
       @session        = Patron::Session.new
       @session.timeout = 10
+      @session.connect_timeout = 10
 
       @session.base_url                 = "https://#{host}"
       @session.headers["Content-Type"]  = "application/json"


### PR DESCRIPTION
I was getting some Patron::TimeoutError because the default HTTP
connection timeout is 1 second.
