### PR TITLE
Updating a fetched object fails.

### DIFF
--- a/lib/parse/protocol.rb
+++ b/lib/parse/protocol.rb
@@ -59,7 +59,7 @@ module Parse
     # increment/decrement API call.
     KEY_AMOUNT      = "amount"
 
-	RESERVED_KEYS = [ KEY_CLASS_NAME, KEY_CREATED_AT, KEY_OBJECT_ID ]
+	RESERVED_KEYS = [ KEY_CLASS_NAME, KEY_CREATED_AT, KEY_OBJECT_ID, KEY_UPDATED_AT]
 
     # Other Constants
     # ----------------------------------------

--- a/test/test_client.rb
+++ b/test/test_client.rb
@@ -30,6 +30,20 @@ class TestClient < Test::Unit::TestCase
     assert_equal foo[Parse::Protocol::KEY_UPDATED_AT].class, String
   end
   
+  def test_server_update
+    foo = Parse::Object.new("TestSave").save 
+    foo["name"] = 'john'
+    foo.save
+    
+    bar = Parse.get("TestSave",foo.id) # pull it from the server
+    assert_equal bar["name"], 'john'
+    bar["name"] = 'dave'
+    bar.save
+    
+    bat = Parse.get("TestSave",foo.id)
+    assert_equal bar["name"], 'dave'
+  end
+  
   def test_destroy
     d = Parse::Object.new "toBeDeleted"
     d["foo"] = "bar"


### PR DESCRIPTION
Let's try that again.

Patch to fix issue #8. 

If you fetch an object from the server using a query, update it, then save it, the save fails because the 'updatedAt' key is not being removed from the batch. The fix is to add the 'updateAt' key to the RESERVED_KEYS list in protocol.rb, patch incoming.

Tests added.
