### PR TITLE
Fix Parse::Object#pointer to include class name

### DIFF
--- a/lib/parse/object.rb
+++ b/lib/parse/object.rb
@@ -24,7 +24,7 @@ module Parse
     end
 
     def pointer
-      Parse::Pointer.new self
+      Parse::Pointer.new self.merge(Parse::Protocol::KEY_CLASS_NAME => class_name)
     end
 
     # Merge a hash parsed from the JSON representation into

--- a/test/test_object.rb
+++ b/test/test_object.rb
@@ -20,6 +20,13 @@ class TestObject < Test::Unit::TestCase
     assert_equal post.id.class, String
   end
 
+  def test_pointer
+    post = Parse::Object.new "Post"
+    pointer = post.pointer
+    assert_equal pointer.parse_object_id, post.parse_object_id
+    assert_equal pointer.class_name, post.class_name
+  end
+
   def test_created_at
     post = Parse::Object.new "Post"
     assert_equal post.created_at, nil


### PR DESCRIPTION
Added test to document prior bug
