### PR TITLE
Query order not being honored

### DIFF
--- a/lib/parse/query.rb
+++ b/lib/parse/query.rb
@@ -9,6 +9,7 @@ module Parse
     attr_accessor :order
     attr_accessor :limit
     attr_accessor :skip
+    attr_accessor :count
 
     def initialize(cls_name)
       @class_name = cls_name
@@ -66,10 +67,16 @@ module Parse
       self
     end
 
+    def count
+      @count = true
+      self
+    end
+
     def get
       uri   = Protocol.class_uri @class_name
       query = { "where" => CGI.escape(@where.to_json) }
       set_order(query)
+      [:count, :limit].each {|a| merge_attribute(a, query)}
 
       response = Parse.client.request uri, :get, nil, query
       Parse.parse_json class_name, response
@@ -84,6 +91,11 @@ module Parse
       query.merge!(:order => order_string)
     end
 
+    def merge_attribute(attribute, query)
+      value = self.instance_variable_get("@#{attribute.to_s}")
+      return if value.nil?
+      query.merge!(attribute => value)
+    end
   end
 
 end


### PR DESCRIPTION
Hi,

The order and order_by attributes of Parse::Query class is not being homered (see issue #5). In fact these variables are not being read at all. I wrote a small fix that solves the issue. Please include if you agree with my change.

Kind regards,
  Mio Nilsson
