### PR TITLE
support array operations

### DIFF
--- a/fixtures/vcr_cassettes/test_array_add.yml
+++ b/fixtures/vcr_cassettes/test_array_add.yml
@@ -1,0 +1,121 @@
+--- 
+http_interactions: 
+- request: 
+    method: post
+    uri: https://api.parse.com/1/classes/Post
+    body: 
+      encoding: UTF-8
+      string: "{\"chapters\":{\"__op\":\"Add\",\"objects\":[\"hello\"]}}"
+    headers: 
+      Content-Type: 
+      - application/json
+      Accept: 
+      - application/json
+      User-Agent: 
+      - Parse for Ruby, 0.0
+      X-Parse-Master-Key: 
+      - ""
+      X-Parse-Rest-Api-Key: 
+      - jYdptjS76YHikuIFfJEgHD8UMIjH6cp2rWz4fo2C
+      X-Parse-Application-Id: 
+      - hnJRtntbYPvWfjqcqLZsdFaOKT0F3SfNU7Kc7woN
+      X-Parse-Session-Token: 
+      - ""
+      Expect: 
+      - ""
+  response: 
+    status: 
+      code: 201
+      message: Created
+    headers: 
+      Access-Control-Allow-Origin: 
+      - "*"
+      Access-Control-Request-Method: 
+      - "*"
+      Cache-Control: 
+      - no-cache
+      Content-Type: 
+      - application/json; charset=utf-8
+      Date: 
+      - Mon, 15 Oct 2012 12:59:15 GMT
+      Location: 
+      - https://api.parse.com/1/classes/Post/ug80aldIcg
+      Server: 
+      - nginx/1.2.2
+      Set-Cookie: 
+      - _parse_session=BAh7BkkiD3Nlc3Npb25faWQGOgZFRiIlMWQwOTljYjU4YzdhNzU3ODc1MzI1MGI1MzQ0YjMwMTE%3D--999bcf56a783c9a250636b41fc4b09c5b3aecce2; domain=.parse.com; path=/; expires=Sat, 15-Oct-2022 12:59:15 GMT; secure; HttpOnly
+      Status: 
+      - 201 Created
+      X-Runtime: 
+      - "0.018886"
+      X-Ua-Compatible: 
+      - IE=Edge,chrome=1
+      Content-Length: 
+      - "64"
+      Connection: 
+      - keep-alive
+    body: 
+      encoding: UTF-8
+      string: "{\"createdAt\":\"2012-10-15T12:59:15.263Z\",\"objectId\":\"ug80aldIcg\"}"
+    http_version: 
+  recorded_at: Mon, 15 Oct 2012 12:59:16 GMT
+- request: 
+    method: put
+    uri: https://api.parse.com/1/classes/Post/ug80aldIcg
+    body: 
+      encoding: UTF-8
+      string: "{\"chapters\":{\"__op\":\"Add\",\"objects\":[\"goodbye\"]}}"
+    headers: 
+      Content-Type: 
+      - application/json
+      Accept: 
+      - application/json
+      User-Agent: 
+      - Parse for Ruby, 0.0
+      X-Parse-Master-Key: 
+      - ""
+      X-Parse-Rest-Api-Key: 
+      - jYdptjS76YHikuIFfJEgHD8UMIjH6cp2rWz4fo2C
+      X-Parse-Application-Id: 
+      - hnJRtntbYPvWfjqcqLZsdFaOKT0F3SfNU7Kc7woN
+      X-Parse-Session-Token: 
+      - ""
+      Expect: 
+      - ""
+  response: 
+    status: 
+      code: 200
+      message: OK
+    headers: 
+      Access-Control-Allow-Origin: 
+      - "*"
+      Access-Control-Request-Method: 
+      - "*"
+      Cache-Control: 
+      - max-age=0, private, must-revalidate
+      Content-Type: 
+      - application/json; charset=utf-8
+      Date: 
+      - Mon, 15 Oct 2012 17:47:28 GMT
+      Etag: 
+      - "\"f99c943f91a9d6fc5e32e11d86b40755\""
+      Server: 
+      - nginx/1.2.2
+      Set-Cookie: 
+      - _parse_session=BAh7BkkiD3Nlc3Npb25faWQGOgZFRiIlMjlkOGYxMGU3YjE4YzgxM2U1NzZjNGNkNmI2MDljZDY%3D--b4c3fa092802887988fae07911e78dce8d1fd453; domain=.parse.com; path=/; expires=Sat, 15-Oct-2022 17:47:28 GMT; secure; HttpOnly
+      Status: 
+      - 200 OK
+      X-Runtime: 
+      - "0.016753"
+      X-Ua-Compatible: 
+      - IE=Edge,chrome=1
+      Content-Length: 
+      - "71"
+      Connection: 
+      - keep-alive
+    body: 
+      encoding: ASCII-8BIT
+      string: "{\"chapters\":[\"hello\",\"goodbye\"],\"updatedAt\":\"2012-10-15T17:47:28.940Z\"}"
+    http_version: 
+  recorded_at: Mon, 15 Oct 2012 17:47:30 GMT
+recorded_with: VCR 2.0.1

--- a/lib/parse/datatypes.rb
+++ b/lib/parse/datatypes.rb
@@ -214,6 +214,40 @@ module Parse
     end
   end
 
+  class ArrayOp
+    # '{"myArray": {"__op": "Add", "objects": ["something", "something else"] } }'
+    attr_accessor :operation
+    attr_accessor :objects
+
+    def initialize(operation, objects)
+      @operation = operation
+      @objects = objects
+    end
+
+    def eql?(other)
+      self.class.equal?(other.class) &&
+        operation == other.operation &&
+        objects == other.objects
+    end
+
+    alias == eql?
+
+    def hash
+      operation.hash ^ objects.hash
+    end
+
+    def as_json(*a)
+      {
+          Protocol::KEY_OP => operation,
+          Protocol::KEY_OBJECTS => @objects
+      }
+    end
+
+    def to_json(*a)
+        as_json.to_json(*a)
+    end
+  end
+
   # GeoPoint
   # ------------------------------------------------------------
 

--- a/lib/parse/protocol.rb
+++ b/lib/parse/protocol.rb
@@ -53,12 +53,18 @@ module Parse
     RESPONSE_KEY_RESULTS = "results"
     KEY_RESULTS = RESPONSE_KEY_RESULTS
 
-    # The JSON key used to identify an operator in the increment/decrement
-    # API call.
+    # The JSON key used to identify an operator
     KEY_OP          = "__op"
+
     KEY_INCREMENT   = "Increment"
     KEY_DECREMENT   = "Decrement"
     KEY_DELETE      = "Delete"
+
+    # array ops
+    KEY_OBJECTS     = "objects"
+    KEY_ADD         = "Add"
+    KEY_ADD_UNIQUE  = "AddUnique"
+    KEY_REMOVE      = "Remove"
 
     DELETE_OP       = { KEY_OP => KEY_DELETE }
 

--- a/test/test_object.rb
+++ b/test/test_object.rb
@@ -107,4 +107,19 @@ class TestObject < Test::Unit::TestCase
       assert_false post.refresh.keys.include?("title")
     end
   end
+
+  def test_array_add
+    VCR.use_cassette('test_array_add', :record => :new_episodes) do
+      post = Parse::Object.new "Post"
+      post.array_add("chapters", "hello")
+      assert_equal ["hello"], post["chapters"]
+      post.save
+      assert_equal ["hello"], post["chapters"]
+
+      post.array_add("chapters", "goodbye")
+      assert_equal ["hello", "goodbye"], post["chapters"]
+      post.save
+      assert_equal ["hello", "goodbye"], post["chapters"]
+    end
+  end
 end


### PR DESCRIPTION
I don't love this because if you mutate the array value manually before or after you do it through an operation the value sent to the server is going to be wrong, but in general we should fix Parse::Object to make our representation of the data and the operations that need to be sent more explicit and make sure it matches the behavior of the official Parse clients.  But it's better than not supporting arrays at all.  I guess we could alias method chain the hash setter to raise if you've used an operation before and the getter to apply the pending operations to the original array and return you a dup of it so you can't mutate it, but that seems like a bit much code...must be a more elegant way to represent Parse::Objects based on the other client libs.  
