### PR TITLE
Parse reset password requires a json body

### DIFF
--- a/lib/parse/user.rb
+++ b/lib/parse/user.rb
@@ -19,7 +19,7 @@ module Parse
 
     def self.reset_password(email)
       body = {"email" => email}
-      Parse.client.post(Parse::Protocol::PASSWORD_RESET_URI, body)
+      Parse.client.post(Parse::Protocol::PASSWORD_RESET_URI, body.to_json)
     end
 
     def initialize(data = nil)


### PR DESCRIPTION
Password reset wasn't working, it needs body.to_json: https://parse.com/docs/rest#users-passwordreset
