### PR TITLE
Added convenience methods for limit and order

### DIFF
--- a/lib/parse/query.rb
+++ b/lib/parse/query.rb
@@ -91,9 +91,9 @@ module Parse
       self
     end
     
-    def order(field, order)
+    def order(field, order = :ascending)
       @order_by = field
-      @order = order ||= :ascending
+      @order = order
       self
     end
 


### PR DESCRIPTION
I've added two convenience methods for order and limit in Parse::Query so you could just one line the whole query.
