### PR TITLE
Push docs & where changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1074,15 +1074,6 @@ push.type = "ios"
 push.save
 ```
 
-To send a notification to the "user_2" channel and only to devices where follows = true
-
-```ruby
-data = { :alert => "Another test notification" }
-push = Parse::Push.new(data, "follows", "user_2")
-push.type = "ios"
-push.save
-```
-
 Notifications by default are set for iOS and Android. You can set certain notifications to only be sent to iOS or Android by setting the `type` to `ios` or `android`.
 
 For config/installation: https://parse.com/docs/rest#push and https://parse.com/docs/push_guide#top/REST

--- a/lib/parse/push.rb
+++ b/lib/parse/push.rb
@@ -11,7 +11,7 @@ module Parse
     attr_accessor :expiration_time
     attr_accessor :data
 
-    def initialize(data, channel = "", where = nil)
+    def initialize(data, channel = "")
       @data = data
       @channel = channel
       @where = where
@@ -28,7 +28,7 @@ module Parse
       end
 
       if @where
-        body.merge!({ :where => {:channels => @channel, @where => true} })
+        body.merge!({ :where => @where })
         body.delete :channel
       end
 


### PR DESCRIPTION
I'm using Parse in my Rails application and I was going to build a Parse ruby client before I found this gem.
I've added some basic docs on Push notifications and I've also changed the way the where option works.
It works in my application fine and I can filter what notifications go to who now.
Hope this helps :smile: 
