### PR TITLE
Add http_status_code to ParseProtocolError.

### DIFF
--- a/lib/faraday/extended_parse_json.rb
+++ b/lib/faraday/extended_parse_json.rb
@@ -15,7 +15,7 @@ module Faraday
           Parse::Protocol::ERROR_TIMEOUT,
           Parse::Protocol::ERROR_EXCEEDED_BURST_LIMIT
         ]
-        error_hash = { "error" => "HTTP Status #{env[:status]} Body #{env[:body]}" }.merge(data)
+        error_hash = { "error" => "HTTP Status #{env[:status]} Body #{env[:body]}", "http_status_code" => env[:status] }.merge(data)
         if data['code'] && array_codes.include?(data['code'])
           sleep 60 if data['code'] == Parse::Protocol::ERROR_EXCEEDED_BURST_LIMIT
           raise exception(env).new(error_hash.merge(data))

--- a/lib/parse/error.rb
+++ b/lib/parse/error.rb
@@ -14,12 +14,14 @@ module Parse
     attr_accessor :code
     attr_accessor :error
     attr_accessor :response
+    attr_accessor :http_status_code
 
     def initialize(response)
       @response = response
       if response
         @code   = response["code"]
         @error  = response["error"]
+        @http_status_code = response["http_status_code"]
       end
 
       super("#{@code}: #{@error}")


### PR DESCRIPTION
Per our conversation at #132 

Crux of this issue is that Parse can return **HTML** (not JSON) with response code of 502 / 503 (Parse's nginx seems to be poorly configured). In this case, the only information we can reliably use is HTTP status code.

Alternatively, I would suggest that we pass `env` to the error as the initialize argument rather than parsed hash, then build the `error_hash` inside the error object, not in the `ExtendedParseJson` class.
