### PR TITLE
add deleting files method

### DIFF
--- a/lib/parse/datatypes.rb
+++ b/lib/parse/datatypes.rb
@@ -334,6 +334,11 @@ module Parse
       resp
     end
 
+    def delete
+      uri = Parse::Protocol.file_uri(@parse_filename)
+      resp = Parse.client.delete(uri)
+    end
+
     def to_h(*a)
       {
         Protocol::KEY_TYPE => Protocol::TYPE_FILE,


### PR DESCRIPTION
Usage:

``` ruby
Parse.init :application_id => "<your_app_id>",
           :api_key        => "<your_api_key>",
           :master_key     => "<your_master_key>",
           :quiet          => true | false     

photo = Parse::File.new({
  :parse_filename => "parse_filename.jpg"
})
photo.delete
```

I didn't add testing code, because I have no idea about testing code.
If you access photo.url, you can see "Access Denied".
But I seem that we cannot test using instance variables of File class.

Would you give me some advice please?
