### PR TITLE
Add missing fields to installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # !! NOTE !!
 The master branch has a lot of changes that the current release doesn't have.
 
-The version on RubyGems (0.3.0) has its [corresponding tag](https://github.com/adelevie/parse-ruby-client/tree/v0.3.0), so use those docs instead. 
+The version on RubyGems (0.3.0) has its [corresponding tag](https://github.com/adelevie/parse-ruby-client/tree/v0.3.0), so use those docs instead.
 
 Alternatively, you can set up your `Gemfile` as such:
 
@@ -1134,20 +1134,31 @@ push.save
 
 ## Installations
 
+#### Creating Installations
+
+```ruby
+installation = client.installation.tap do |i|
+  i.device_token = 'mobile_app_device_token'
+  i.device_type = 'ios'
+  i.channels = ['my-channel-name']
+end
+installation.save
+```
+
 #### Retrieving Installations
 
 ```ruby
-installation = Parse::Installation.get("objectId", client)
+installation = client.installation('objectId').get
 # Same as
-installation = Parse::Installation.new("objectId", client)
+installation = Parse::Installation.new('objectId', client)
 installation.get
 ```
 
 #### Updating installations
 
 ```ruby
-installation = Parse::Installation.new("objectId", client)
-installation.channels = ["", "my-channel-name"]
+installation = client.installation('objectId')
+installation.channels = ['', 'my-channel-name']
 installation.badge = 5
 installation.save
 ```

--- a/fixtures/vcr_cassettes/test_create_invalid_installation.yml
+++ b/fixtures/vcr_cassettes/test_create_invalid_installation.yml
@@ -1,0 +1,51 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.parse.com/1/installations
+    body:
+      encoding: UTF-8
+      string: '{"deviceToken":"123","deviceType":"ios"}'
+    headers:
+      User-Agent:
+      - Parse for Ruby, 0.0
+      Content-Type:
+      - application/json
+      X-Parse-Master-Key:
+      - "<X-Parse-Master-Key>"
+      X-Parse-Application-Id:
+      - "<X-Parse-Application-Id>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 400
+      message: Bad Request
+    headers:
+      Access-Control-Allow-Methods:
+      - "*"
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Sun, 14 Jun 2015 15:46:20 GMT
+      Server:
+      - nginx/1.6.0
+      X-Parse-Platform:
+      - G1
+      X-Runtime:
+      - '0.028175'
+      Content-Length:
+      - '49'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: |
+        {"code":114,"error":"Invalid device token: 123"}
+    http_version: 
+  recorded_at: Sun, 14 Jun 2015 15:46:20 GMT
+recorded_with: VCR 2.9.3

--- a/fixtures/vcr_cassettes/test_create_valid_installation.yml
+++ b/fixtures/vcr_cassettes/test_create_valid_installation.yml
@@ -1,0 +1,53 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.parse.com/1/installations
+    body:
+      encoding: UTF-8
+      string: '{"deviceToken":"0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef","deviceType":"ios"}'
+    headers:
+      User-Agent:
+      - Parse for Ruby, 0.0
+      Content-Type:
+      - application/json
+      X-Parse-Master-Key:
+      - "<X-Parse-Master-Key>"
+      X-Parse-Application-Id:
+      - "<X-Parse-Application-Id>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Access-Control-Allow-Methods:
+      - "*"
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Sun, 14 Jun 2015 15:46:21 GMT
+      Location:
+      - https://api.parse.com/1/installations/ZfBPt6aQ4j
+      Server:
+      - nginx/1.6.0
+      X-Parse-Platform:
+      - G1
+      X-Runtime:
+      - '0.035753'
+      Content-Length:
+      - '65'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: |
+        {"createdAt":"2015-06-14T15:46:21.131Z","objectId":"ZfBPt6aQ4j"}
+    http_version: 
+  recorded_at: Sun, 14 Jun 2015 15:46:21 GMT
+recorded_with: VCR 2.9.3

--- a/lib/parse/client.rb
+++ b/lib/parse/client.rb
@@ -111,6 +111,10 @@ module Parse
       Parse::Push.new(data, channel, self)
     end
 
+    def installation(object_id = nil)
+      Parse::Installation.new(object_id, self)
+    end
+
     def query(class_name)
       Parse::Query.new(class_name, self)
     end

--- a/lib/parse/installation.rb
+++ b/lib/parse/installation.rb
@@ -11,6 +11,9 @@ module Parse
       badge: 'badge',
       channels: 'channels',
       time_zone: 'timeZone',
+      device_type: 'deviceType',
+      push_type: 'pushType',
+      gcm_sender_id: 'GCMSenderId',
       device_token: 'deviceToken',
       channel_uris: 'channelUris',
       app_name: 'appName',
@@ -25,14 +28,13 @@ module Parse
     end
 
     def self.get(parse_object_id, client = nil)
-      client ||= Parse.client
-      new(parse_object_id, client = client).get
+      new(parse_object_id, client).get
     end
 
     def get
-      if response = @client.request(uri, :get, nil, nil)
-        parse Parse.parse_json(nil, response)
-      end
+      response = client.request(uri, :get, nil, nil)
+
+      parse Parse.parse_json(nil, response) if response
     end
 
     UPDATABLE_FIELDS.each do |method_name, key|
@@ -46,7 +48,7 @@ module Parse
     end
 
     def save
-      @client.request uri, method, self.to_json, nil
+      client.request uri, method, to_json, nil
     end
 
     def rest_api_hash
@@ -56,6 +58,5 @@ module Parse
     def method
       @parse_object_id ? :put : :post
     end
-
   end
 end

--- a/test/test_installation.rb
+++ b/test/test_installation.rb
@@ -1,6 +1,29 @@
 require 'helper'
 
 class TestInstallation < ParseTestCase
+  def test_create_installation_with_valid_data
+    VCR.use_cassette('test_create_valid_installation') do
+      installation = @client.installation.tap do |i|
+        i.device_token = '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef'
+        i.device_type = 'ios'
+      end.save
+
+      assert_equal installation['createdAt'].class, String
+      assert_equal installation['objectId'].class, String
+    end
+  end
+
+  def test_create_installation_with_invalid_data
+    VCR.use_cassette('test_create_invalid_installation') do
+      installation = @client.installation.tap do |i|
+        i.device_token = '123'
+        i.device_type = 'ios'
+      end
+
+      assert_raises(Parse::ParseProtocolError) { installation.save }
+    end
+  end
+
   def test_retrieving_installation_data
     installation_data = {
       "appIdentifier"=>"net.project_name",
@@ -19,25 +42,25 @@ class TestInstallation < ParseTestCase
     }
 
     VCR.use_cassette('test_get_installation') do
-      installation = Parse::Installation.get("987", client = @client)
-      assert_equal installation_data, installation
+      data = Parse::Installation.get('987', @client)
+      assert_equal installation_data, data
     end
   end
 
   def test_changing_channels
-    installation = Parse::Installation.new("987", client = @client)
+    installation = Parse::Installation.new('987', @client)
     installation.channels = ["", "my-channel"]
     assert_equal ["", "my-channel"], installation["channels"]
   end
 
   def test_changing_badges
-    installation = Parse::Installation.new("987", client = @client)
+    installation = Parse::Installation.new('987', @client)
     installation.badge = 5
     assert_equal 5, installation["badge"]
   end
 
   def test_updating_installation_data
-    installation = Parse::Installation.new("987", client = @client)
+    installation = Parse::Installation.new('987', @client)
     installation.channels = ["", "my-channel"]
     installation.badge = 5
 


### PR DESCRIPTION
As per [Uploading installation data](https://parse.com/docs/rest/guide/#push-notifications-uploading-installation-data) section of Parse documentation installation object includes such fields as `deviceType`, `pushType`, `GCMSenderId`, `installationId` which were not listed in this gem.

As per documentation these fields are readonly, but they must be used to create new records, so I think they should be specified in `UPDATABLE_FIELDS` array.

Also I've added a method `Parse::Installation.build` which can be used to build new installation object using REST API. This method is just a sugar, because now you also could create installation objects using something like this:

```
Parse::Installation.new(nil, client).tap do |obj|
  obj['deviceToken'] = 'device_token_here'
  obj['deviceType'] = 'ios'
end
```

With this method it comes a little bit more nice

```
Parse::Installation.build(client).tap do |obj|
  obj['deviceToken'] = 'device_token_here'
  obj['deviceType'] = 'ios'
end
```

Also I've made some code improvements, removed explicit variable assignments and assignment in condition.