### PR TITLE
Improve Parse::Client: handle more errors and expose more Faraday options so we can change it easily

### DIFF
--- a/lib/parse/client.rb
+++ b/lib/parse/client.rb
@@ -14,7 +14,7 @@ module Parse
       'Faraday::Error::ParsingError',
       'Faraday::Error::ConnectionFailed',
       'Parse::ParseProtocolRetry'
-    ].freeze
+    ]
 
     attr_accessor :host
     attr_accessor :application_id


### PR DESCRIPTION
**What is this PR for?**
We are using `parse-ruby-client` on our production and experiencing a lot of errors like these:
* Faraday::TimeoutError: execution expired
* Faraday::ConnectionFailed: Connection reset by peer - SSL_connect
* Faraday::TimeoutError: Net::ReadTimeout

After inspecting the code, we found out that there is no way to change the `timeout` but the monkey patch, because we hard-code it!
Another reason is sometimes the retry does not work with some error like `Faraday::ConnectionFailed`. We don't think it is the SSL problem, because we checked our server's certificates, and it's okay.

After we applied this patch, and adjusted the `timeout` and `backoff_factor` options, the error rate was significantly reduced.

Any comments is appreciated!