### PR TITLE
choose application name when creating client from global.json

### DIFF
--- a/lib/parse/client.rb
+++ b/lib/parse/client.rb
@@ -178,9 +178,9 @@ module Parse
     end
 
     # A convenience method for using global.json
-    def init_from_cloud_code(path = '../config/global.json')
+    def init_from_cloud_code(path = '../config/global.json', application_name = nil)
       global = JSON.parse(::File.open(path).read)
-      application_name  = global['applications']['_default']['link']
+      application_name  = global['applications']['_default']['link'] if application_name.nil?
       application_id    = global['applications'][application_name]['applicationId']
       master_key        = global['applications'][application_name]['masterKey']
       create(application_id: application_id, master_key: master_key)


### PR DESCRIPTION
We have many parse clouds set up for testing in our global.json. This change allows to choose which cloud should be taken upon creation of the client from the global.json. Backwards compatibility is maintained.