### PR TITLE
Using whole host url as input including scheme: compatibility with parse-server

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,19 @@ Parse.create :application_id => "<your_app_id>", # required
              :api_key        => "<your_api_key>", # required
              :quiet          => true | false  # optional, defaults to false
 ```
+You can also specify your host if you are hosting your own parse-server:
+
+```ruby
+require 'parse-ruby-client'
+
+Parse.create :application_id => "<your_app_id>", # required
+             :api_key        => "<your_api_key>", # required
+             :quiet          => true | false  # optional, defaults to false
+             :host           => "http://custom-parse-server-without-backslash"
+
+```
+Please specify the url you mounted the api server without backslash as the ``host`` when
+instantiating the ``client``
 
 [![Gem Version](https://img.shields.io/gem/v/parse-ruby-client.svg)](http://badge.fury.io/rb/parse-ruby-client)
 

--- a/lib/parse/client.rb
+++ b/lib/parse/client.rb
@@ -50,7 +50,7 @@ module Parse
 
       options = { request: { timeout: @timeout, open_timeout: @timeout } }
 
-      @session = Faraday.new("https://#{host}", options) do |c|
+      @session = Faraday.new(host, options) do |c|
         c.request :json
 
         c.use Faraday::GetMethodOverride

--- a/lib/parse/protocol.rb
+++ b/lib/parse/protocol.rb
@@ -6,7 +6,7 @@ module Parse
     # ----------------------------------------
 
     # The default hostname for communication with the Parse API.
-    HOST            = 'api.parse.com'
+    HOST            = 'https://api.parse.com'
 
     # The version of the REST API implemented by this module.
     VERSION         = 1

--- a/lib/parse/protocol.rb
+++ b/lib/parse/protocol.rb
@@ -6,7 +6,7 @@ module Parse
     # ----------------------------------------
 
     # The default hostname for communication with the Parse API.
-    HOST            = 'https://api.parse.com'
+    HOST            = 'https://api.parse.com/1'
 
     # The version of the REST API implemented by this module.
     VERSION         = 1
@@ -117,8 +117,8 @@ module Parse
 
     CLASS_INSTALLATION = '_Installation'
 
-    USER_LOGIN_URI  = "/#{VERSION}/login"
-    PASSWORD_RESET_URI = "/#{VERSION}/requestPasswordReset"
+    USER_LOGIN_URI  = "/login"
+    PASSWORD_RESET_URI = "/requestPasswordReset"
 
     CLOUD_FUNCTIONS_PATH = 'functions'
 
@@ -133,16 +133,16 @@ module Parse
     # ----------------------------------------
 
     def self.config_uri
-      "/#{VERSION}/config"
+      "/config"
     end
 
     # Construct a uri referencing a given Parse object
     # class or instance (of object_id is non-nil).
     def self.class_uri(class_name, object_id = nil)
       if object_id
-        "/#{VERSION}/classes/#{class_name}/#{object_id}"
+        "/classes/#{class_name}/#{object_id}"
       else
-        "/#{VERSION}/classes/#{class_name}"
+        "/classes/#{class_name}"
       end
     end
 
@@ -150,9 +150,9 @@ module Parse
     # class or instance (of object_id is non-nil).
     def self.installation_uri(object_id = nil)
       if object_id
-        "/#{VERSION}/installations/#{object_id}"
+        "/installations/#{object_id}"
       else
-        "/#{VERSION}/installations"
+        "/installations"
       end
     end
 
@@ -160,28 +160,28 @@ module Parse
     # instance or the users category.
     def self.user_uri(user_id = nil)
       if user_id
-        "/#{VERSION}/users/#{user_id}"
+        "/users/#{user_id}"
       else
-        "/#{VERSION}/users"
+        "/users"
       end
     end
 
     # Construct a uri referencing a file stored by the API.
     def self.file_uri(file_name)
-      "/#{VERSION}/files/#{file_name}"
+      "/files/#{file_name}"
     end
 
     # Construct a uri to send a push notification via the API.
     def self.push_uri
-      "/#{VERSION}/push"
+      "/push"
     end
 
     def self.cloud_function_uri(function_name)
-      "/#{VERSION}/#{CLOUD_FUNCTIONS_PATH}/#{function_name}"
+      "/#{CLOUD_FUNCTIONS_PATH}/#{function_name}"
     end
 
     def self.batch_request_uri
-      "/#{VERSION}/#{BATCH_REQUEST_URI}"
+      "/#{BATCH_REQUEST_URI}"
     end
   end
 end


### PR DESCRIPTION
Hi,

With the parse server transition, it will be better to not hardcode or enforce the https scheme as the host url but let the user set the host dynamically (https is tedious to setup in a local server). 

I will also suggest that we should just remove the VERSION field in ``protocol`` module. 