### PR TITLE
Adding master key to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ require 'parse-ruby-client'
 
 Parse.create :application_id => "<your_app_id>", # required
              :api_key        => "<your_api_key>", # required
+             :master_key     => "<your_master_key>", # optional, defaults to nil
              :quiet          => true | false,  # optional, defaults to false
              :host           => 'http://localhost:1337', # optional, defaults to 'https://api.parse.com'
              :path           => '/parse', # optional, defaults to '/1'


### PR DESCRIPTION
Some parse calls require a master key so I wanted to update the documentation to reflect that