### PR TITLE
Use $in syntax for channels when they are in query.

### DIFF
--- a/lib/parse/push.rb
+++ b/lib/parse/push.rb
@@ -19,7 +19,7 @@ module Parse
       @data = data
 
       # NOTE: if no channel is specified, by setting "where" to an empty clause
-      #   a push is sent to all clients.
+      # a push is sent to all clients.
       if !channel || channel.empty?
         @where = {}
       else
@@ -44,7 +44,7 @@ module Parse
       # so we make channels part of the query conditions
       if @channels
         if @where
-          @where[:channels] = @channels
+          @where[:channels] = { '$in' => @channels }
         else
           body[:channels] = @channels
         end

--- a/test/test_push.rb
+++ b/test/test_push.rb
@@ -103,7 +103,12 @@ class TestPush < ParseTestCase
       body = JSON.parse(body)
       expected_result = {
         'data' => { 'alert' => 'foobar' },
-        'where' => { 'channels' => ['foobar'], 'appName' => 'Test' }
+        'where' => {
+          'channels' => {
+            '$in' => %w(foobar)
+          },
+          'appName' => 'Test'
+        }
       }
       assert_equal expected_result, body
 
@@ -125,7 +130,7 @@ class TestPush < ParseTestCase
       body = JSON.parse(body)
       expected_result = {
         'data' => { 'alert' => 'foobar' },
-        'where' => { 'channels' => %w(abcdef bcdefg) }
+        'where' => { 'channels' => { '$in' => %w(abcdef bcdefg) } }
       }
       assert_equal expected_result, body
 


### PR DESCRIPTION
fixes issue described in https://github.com/adelevie/parse-ruby-client/issues/190