### PR TITLE
No parse com

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,11 +35,11 @@ We support Ruby 2.1 and newer and JRuby 9000. Older versions are not supported, 
 require 'parse-ruby-client'
 
 Parse.create :application_id      => "<your_app_id>", # required
-             :api_key             => "<your_api_key>", # optional, defaults to nil
-             :master_key          => "<your_master_key>", # optional, defaults to nil
-             :quiet               => true | false,  # optional, defaults to false
-             :host                => 'http://localhost:1337', # optional, defaults to 'https://api.parse.com'
+             :master_key          => "<your_master_key>", # required
+             :host                => 'http://localhost:1337', # required
              :path                => '/parse', # optional, defaults to '/1'
+             :api_key             => "<your_api_key>", # optional, defaults to nil
+             :quiet               => true | false,  # optional, defaults to false
              :get_method_override => true | false, # optional, defaults to true
 ```
 
@@ -1080,7 +1080,7 @@ The response body is a `Hash` object containing the name of the file, which is t
 
 ```ruby
 {"url"=>
-  "http://files.parse.com/372fcbb9-7eae-4b9a-abc8-6da97fcac50d/98f06e15-d6e6-42a9-a9cd-7d28ec98052c-hello.txt",
+  "http://something.com/somewhere/98f06e15-d6e6-42a9-a9cd-7d28ec98052c-hello.txt",
  "name"=>"98f06e15-d6e6-42a9-a9cd-7d28ec98052c-hello.txt"}
 ```
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ require 'parse-ruby-client'
 
 Parse.create :application_id      => "<your_app_id>", # required
              :host                => 'http://localhost:1337', # required
-             :path                => '/parse', # optional, defaults to '/1'
+             :path                => '/parse', # optional, defaults to '/parse'
              :master_key          => "<your_master_key>", # optional, defaults to nil
              :api_key             => "<your_api_key>", # optional, defaults to nil
              :quiet               => true | false,  # optional, defaults to false

--- a/README.md
+++ b/README.md
@@ -35,9 +35,9 @@ We support Ruby 2.1 and newer and JRuby 9000. Older versions are not supported, 
 require 'parse-ruby-client'
 
 Parse.create :application_id      => "<your_app_id>", # required
-             :master_key          => "<your_master_key>", # required
              :host                => 'http://localhost:1337', # required
              :path                => '/parse', # optional, defaults to '/1'
+             :master_key          => "<your_master_key>", # optional, defaults to nil
              :api_key             => "<your_api_key>", # optional, defaults to nil
              :quiet               => true | false,  # optional, defaults to false
              :get_method_override => true | false, # optional, defaults to true

--- a/lib/parse-ruby-client.rb
+++ b/lib/parse-ruby-client.rb
@@ -1,9 +1,9 @@
 # encoding: utf-8
 ## ----------------------------------------------------------------------
 ##
-## Ruby client for parse.com
-## A quick library for playing with parse.com's REST API for object storage.
-## See https://parse.com/docs/rest/guide/ for full documentation on the API.
+## Ruby client for Parse API
+## A quick library for playing with Parse REST API for object storage.
+## See https://parseplatform.github.io/docs/rest/guide/ for full documentation on the API.
 ##
 ## ----------------------------------------------------------------------
 require 'rubygems'

--- a/lib/parse/application.rb
+++ b/lib/parse/application.rb
@@ -1,7 +1,7 @@
 # encoding: utf-8
 module Parse
   # Parse Application
-  # https://parse.com/docs/rest/guide/#config
+  # https://parseplatform.github.io/docs/rest/guide/#config
   class Application
     def self.config(client = nil)
       client ||= Parse.client

--- a/lib/parse/batch.rb
+++ b/lib/parse/batch.rb
@@ -1,7 +1,7 @@
 # encoding: utf-8
 module Parse
   # Issue batch operations
-  # https://parse.com/docs/rest/guide/#objects-batch-operations
+  # https://parseplatform.github.io/docs/rest/guide/#batch-operations
   class Batch
     attr_reader :requests
     attr_accessor :client

--- a/lib/parse/client.rb
+++ b/lib/parse/client.rb
@@ -172,13 +172,14 @@ module Parse
     # This should be preferred over Parse.init which uses a singleton
     # client object for all API calls.
     def create(data = {}, &blk)
-      defaults = {
+      options = defaults = {
         application_id: ENV['PARSE_APPLICATION_ID'],
         master_key: ENV['PARSE_MASTER_API_KEY'],
+        api_key: ENV['PARSE_REST_API_KEY'],
         get_method_override: true
-      }
+      }.merge(data)
 
-      Client.new(defaults.merge(data), &blk)
+      Client.new(options, &blk)
     end
 
     # DEPRECATED: Please use create instead.

--- a/lib/parse/client.rb
+++ b/lib/parse/client.rb
@@ -33,11 +33,13 @@ module Parse
     attr_reader :get_method_override
 
     def initialize(data = {}, &_blk)
-      @host           = data[:host] || Protocol::HOST
+      @host           = data[:host]
       @path           = data[:path] || Protocol::PATH
+
       @application_id = data[:application_id]
-      @api_key        = data[:api_key]
       @master_key     = data[:master_key]
+
+      @api_key        = data[:api_key]
       @session_token  = data[:session_token]
       @max_retries    = data[:max_retries] || 3
       @logger         = data[:logger] || Logger
@@ -171,17 +173,11 @@ module Parse
     def create(data = {}, &blk)
       defaults = {
         application_id: ENV['PARSE_APPLICATION_ID'],
-        api_key: ENV['PARSE_REST_API_KEY'],
+        master_key: ENV['PARSE_MASTER_API_KEY'],
         get_method_override: true
       }
-      defaults.merge!(data)
 
-      # use less permissive key if both are specified
-      unless data[:master_key] || defaults[:api_key]
-        defaults[:master_key] = ENV['PARSE_MASTER_API_KEY']
-      end
-
-      Client.new(defaults, &blk)
+      Client.new(defaults.merge(data), &blk)
     end
 
     # DEPRECATED: Please use create instead.

--- a/lib/parse/cloud.rb
+++ b/lib/parse/cloud.rb
@@ -2,7 +2,7 @@
 module Parse
   module Cloud
     # Call cloud functions
-    # https://parse.com/docs/rest/guide/#cloud-code-cloud-functions
+    # https://parseplatform.github.io/docs/cloudcode/guide/
     class Function
       attr_accessor :function_name
       attr_accessor :client

--- a/lib/parse/datatypes.rb
+++ b/lib/parse/datatypes.rb
@@ -5,7 +5,7 @@ require 'base64'
 
 module Parse
   # A pointer to a Parse object
-  # https://parse.com/docs/rest/guide/#objects-data-types
+  # https://parseplatform.github.io/docs/rest/guide/#data-types
   class Pointer
     attr_accessor :parse_object_id
     attr_accessor :class_name
@@ -66,7 +66,7 @@ module Parse
   end
 
   # A Parse Date
-  # https://parse.com/docs/rest/guide/#objects-data-types
+  # https://parseplatform.github.io/docs/rest/guide/#data-types
   class Date
     attr_accessor :value
 
@@ -170,7 +170,7 @@ module Parse
   end
 
   # Increment (or decrement) counter
-  # https://parse.com/docs/rest/guide/#objects-counters
+  # https://parseplatform.github.io/docs/rest/guide/#counters
   class Increment
     attr_accessor :amount
 
@@ -202,7 +202,7 @@ module Parse
   end
 
   # Array operation
-  # https://parse.com/docs/rest/guide/#objects-arrays
+  # https://parseplatform.github.io/docs/rest/guide/#arrays
   class ArrayOp
     attr_accessor :operation
     attr_accessor :objects
@@ -237,7 +237,7 @@ module Parse
   end
 
   # GeoPoint
-  # https://parse.com/docs/rest/guide/#geopoints
+  # https://parseplatform.github.io/docs/rest/guide/#geopoints
   class GeoPoint
     attr_accessor :longitude, :latitude
 
@@ -276,7 +276,7 @@ module Parse
   end
 
   # File
-  # https://parse.com/docs/rest/guide/#files
+  # https://parseplatform.github.io/docs/rest/guide/#uploading-files
   class File
     attr_accessor :local_filename
     attr_accessor :parse_filename

--- a/lib/parse/installation.rb
+++ b/lib/parse/installation.rb
@@ -6,7 +6,7 @@ require 'parse/object'
 
 module Parse
   # Installation object
-  # https://parse.com/docs/rest/guide/#push-notifications-installations
+  # https://parseplatform.github.io/docs/rest/guide/#installations
   class Installation < Parse::Object
     attr_accessor :client
 

--- a/lib/parse/object.rb
+++ b/lib/parse/object.rb
@@ -5,7 +5,7 @@ require 'parse/error'
 
 module Parse
   # A Parse object
-  # https://parse.com/docs/rest/guide/#objects
+  # https://parseplatform.github.io/docs/rest/guide/#object-format
   class Object < Hash
     attr_reader :parse_object_id
     attr_reader :class_name

--- a/lib/parse/protocol.rb
+++ b/lib/parse/protocol.rb
@@ -5,9 +5,8 @@ module Parse
     # Basics
     # ----------------------------------------
 
-    # The default hostname and path for communication with the Parse API.
-    HOST            = 'https://api.parse.com'
-    PATH            = '/1'
+    # The default path for communication with the Parse API.
+    PATH            = '/parse'
 
     # HTTP Headers
     # ----------------------------------------

--- a/lib/parse/push.rb
+++ b/lib/parse/push.rb
@@ -4,7 +4,7 @@ require 'parse/error'
 
 module Parse
   # Push notification
-  # https://parse.com/docs/rest/guide/#push-notifications
+  # https://parseplatform.github.io/docs/rest/guide/#push-notification
   class Push
     attr_accessor :channels
     attr_accessor :where

--- a/lib/parse/query.rb
+++ b/lib/parse/query.rb
@@ -1,7 +1,7 @@
 # encoding: utf-8
 module Parse
   # Query objects
-  # https://parse.com/docs/rest/guide/#queries
+  # https://parseplatform.github.io/docs/rest/guide/#queries
   class Query
     attr_accessor :where
     attr_accessor :class_name

--- a/lib/parse/user.rb
+++ b/lib/parse/user.rb
@@ -6,7 +6,7 @@ require 'parse/object'
 
 module Parse
   # A Parse User
-  # https://parse.com/docs/rest/guide/#users
+  # https://parseplatform.github.io/docs/rest/guide/#users
   class User < Parse::Object
     def self.authenticate(username, password, client = nil)
       body = {

--- a/lib/parse/version.rb
+++ b/lib/parse/version.rb
@@ -1,4 +1,4 @@
 # encoding: utf-8
 module Parse
-  VERSION = '1.0.0.alpha2'
+  VERSION = '1.0.0.alpha3'
 end

--- a/parse-ruby-client.gemspec
+++ b/parse-ruby-client.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |spec|
   spec.authors       = ["Alan deLevie", "Adam Alpern", "David Brownman", "rhymes"]
 
 
-  spec.summary       = %q{A simple Ruby client for the parse.com REST API}
+  spec.summary       = %q{A simple Ruby client for the Parse REST API}
   spec.homepage      = "http://github.com/adelevie/parse-ruby-client"
   spec.license       = "MIT"
 

--- a/test/test_cloud.rb
+++ b/test/test_cloud.rb
@@ -2,13 +2,6 @@
 require 'helper'
 
 class TestCloud < ParseTestCase
-  # functions stored in test/cloud_functions/MyCloudCode
-  # see https://parse.com/docs/cloud_code_guide to learn how to use Parse Cloud Code
-  #
-  # Parse.Cloud.define('trivial', function(request, response) {
-  #   response.success(request.params);
-  # });
-
   def test_cloud_function_initialize
     cloud_function = Parse::Cloud::Function.new('trivial', @client)
     assert cloud_function.function_name == 'trivial'


### PR DESCRIPTION
This branch makes the following changes:

- application_id is the only required key (see https://parseplatform.github.io/docs/parse-server/guide/#keys)
- all the other keys are still optional
- host does not have a default anymore
- path still defaults to '/1' (should we change it to '/parse' ?)

Refs #217 