### PR TITLE
CI: Use same Ruby version matrix as Ruby, repair for Faraday 1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,10 @@
 language: ruby
-sudo: false
+
 rvm:
+- 2.7
+- 2.6
 - 2.5
-- 2.4
-- 2.3
-- 2.2
-- 2.1
-- jruby-9.1.7.0
+
 env:
   global:
   - PARSE_HOST=https://parse-ruby-client-server.herokuapp.com

--- a/lib/faraday/better_retry.rb
+++ b/lib/faraday/better_retry.rb
@@ -33,8 +33,10 @@ module Faraday
           log(env, exception)
           retries -= 1
           retries_header(env, retries)
-          sleep sleep_amount(retries + 1)
-          retry
+          if (sleep_amount = calculate_sleep_amount(retries + 1, env))
+            sleep sleep_amount
+            retry
+          end
         end
         raise
       end

--- a/lib/faraday/better_retry.rb
+++ b/lib/faraday/better_retry.rb
@@ -12,11 +12,11 @@ module Faraday
       super(app, options)
 
       # NOTE: Faraday 0.9.1 by default does not retry on POST requests
-      @options.methods << :post
+      @options.methods = @options.methods + [:post]
 
       # NOTE: the default exceptions are lost when custom ones are given
       default_exceptions = [
-        Errno::ETIMEDOUT, 'Timeout::Error', Error::TimeoutError]
+        Errno::ETIMEDOUT, 'Timeout::Error', TimeoutError]
       @options.exceptions.concat(default_exceptions)
     end
 

--- a/lib/parse/client.rb
+++ b/lib/parse/client.rb
@@ -104,7 +104,7 @@ module Parse
 
     # NOTE: Don't leak our internal libraries to our clients.
     # Extend this list of exceptions as needed.
-    rescue Faraday::Error::ClientError => e
+    rescue Faraday::ClientError => e
       raise Parse::ConnectionError, e.message
     end
 

--- a/lib/parse/client.rb
+++ b/lib/parse/client.rb
@@ -10,9 +10,9 @@ module Parse
   # The client that communicates with the Parse server via REST
   class Client
     RETRIED_EXCEPTIONS = [
-      'Faraday::Error::TimeoutError',
-      'Faraday::Error::ParsingError',
-      'Faraday::Error::ConnectionFailed',
+      'Faraday::TimeoutError',
+      'Faraday::ParsingError',
+      'Faraday::ConnectionFailed',
       'Parse::ParseProtocolRetry'
     ]
 
@@ -104,7 +104,7 @@ module Parse
 
     # NOTE: Don't leak our internal libraries to our clients.
     # Extend this list of exceptions as needed.
-    rescue Faraday::ClientError => e
+    rescue Faraday::ClientError, Faraday::ConnectionFailed => e
       raise Parse::ConnectionError, e.message
     end
 

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -26,7 +26,7 @@ require 'minitest/focus'
 
 # mocha + minitest
 require 'minitest/unit'
-require 'mocha/mini_test'
+require 'mocha/minitest'
 
 require 'vcr'
 

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -40,10 +40,6 @@ $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 $LOAD_PATH.unshift(File.dirname(__FILE__))
 require 'parse-ruby-client'
 
-if RUBY_VERSION[0..2] < '2.2'
-  YAML::ENGINE.yamler = 'syck' # get ascii strings as strings in fixtures
-end
-
 VCR.configure do |c|
   c.cassette_library_dir = 'test/fixtures/vcr_cassettes'
   c.default_cassette_options = { record: :once }

--- a/test/middleware/better_retry_test.rb
+++ b/test/middleware/better_retry_test.rb
@@ -14,8 +14,8 @@ module Middleware
       default_options = {
         logger: @logger,
         exceptions: [
-          'Faraday::Error::TimeoutError',
-          'Faraday::Error::ParsingError',
+          'Faraday::TimeoutError',
+          'Faraday::ParsingError',
           'Parse::ParseProtocolRetry'
         ]
       }

--- a/test/middleware/extend_parse_json_test.rb
+++ b/test/middleware/extend_parse_json_test.rb
@@ -18,7 +18,7 @@ module Middleware
     end
 
     def test_invalid_json
-      assert_raises(Faraday::Error::ParsingError) { conn.get('/invalid_json') }
+      assert_raises(Faraday::ParsingError) { conn.get('/invalid_json') }
     end
 
     def test_valid_json

--- a/test/test_client_create.rb
+++ b/test/test_client_create.rb
@@ -61,7 +61,7 @@ class TestClientCreate < ParseTestCase
     VCR.use_cassette('test_client_wraps_connection_errors') do
       _stubs, client = stubbed_client do |stub|
         stub.get(stub_path) do
-          raise Faraday::Error::ConnectionFailed, 'message'
+          raise Faraday::ConnectionFailed, 'message'
         end
       end
 


### PR DESCRIPTION
This PR wants to use latest released Faraday.
⚠️ This is a work in progress. Some bits remain. Will update this Description when finalized.

## Background

### CI changes

This PR adds new Ruby versions and removes old ones.

The Ruby support schedule currently contains 2.5-2.7. https://www.ruby-lang.org/en/downloads/branches/ - and, people who are using this gem to communicate with Parse probably run those supported Ruby versions.

This PR also removes the no-longer-used Travis setting `sudo: false`. See [more at the Travis blog](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration).

### Faraday middleware change

The Retry middleware changed enough upstream in 1.0 that the local overrides here make it troublesome.

## Details

- Faraday 1.0 changed namespace on some of the classes
- The retry middleware changed, a little, too
