### PR TITLE
Keep Faraday < 0.15.0 to keep builds  🟢

### DIFF
--- a/parse-ruby-client.gemspec
+++ b/parse-ruby-client.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.1'
 
-  spec.add_dependency 'faraday', '>= 0.9.2'
+  spec.add_dependency 'faraday', ['>= 0.9.2', '< 0.15.0']
   spec.add_dependency 'faraday_middleware', '>= 0.9.2'
 
   spec.add_development_dependency 'bundler'

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -26,7 +26,7 @@ require 'minitest/focus'
 
 # mocha + minitest
 require 'minitest/unit'
-require 'mocha/mini_test'
+require 'mocha/minitest'
 
 require 'vcr'
 


### PR DESCRIPTION
Fixes #227 

This PR edits the gemspec to hold back Faraday to versions before 0.15.0.

Build is 🟢 

## Background

The reason for keeping the version pinned now is that the Retry middleware in this gem depends on details in Faraday < 0.15.0.

A future-proof fix would be to make this gem use Faraday 1.0 (new error classes, new retry internals) and base this gem's retry middleware on newer Faraday stuff.

## Solution

- add version pin on Faraday, so that people don't need to _know_ to be able to use it.
- make mocha's minitest integration load - a new name for the require